### PR TITLE
Fix dependency issue: specify numpy version to avoid compatibility errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
   "sdk",
 ]
 license = { file = "LICENSE" }
-dependencies = ["requests==2.28.2", "pandas==1.5.3", "appdirs==1.4.4"]
+dependencies = ["requests==2.28.2", "pandas==1.5.3", "appdirs==1.4.4", "numpy==1.26.4"]
 
 [project.urls]
 repository = "https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "aurora_origin_sdk"
-version = "0.22.1"
+version = "0.22.2"
 authors = [
   { name = "Aurora Development", email = "aurora_development@auroraer.com" },
 ]


### PR DESCRIPTION
[ORIGIN-1189]

- Added numpy==1.26.4 to dependencies to ensure compatibility with pandas==1.5.3
- This resolves the ValueError due to binary incompatibility between numpy and pandas

[ORIGIN-1189]: https://auroraenergy.atlassian.net/browse/ORIGIN-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ