### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Run Tests and Linters
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk/security/code-scanning/1](https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk/security/code-scanning/1)

To resolve the issue, add a `permissions` block to the root of the workflow or within the specific job (`run_tests`). The `permissions` block should limit the `GITHUB_TOKEN` to the least privileges required. For this workflow:
- `contents: read` will suffice for reading repository contents during checkout.
- No additional permissions (e.g., `write`) are required since the workflow does not perform any write operations.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
