### PR TITLE
Fix ambiguous download error for GBR technology data with subType

### DIFF
--- a/src/origin_sdk/service/Scenario.py
+++ b/src/origin_sdk/service/Scenario.py
@@ -170,6 +170,11 @@ class Scenario:
             {
                 "type": definition.get("type"),
                 "granularity": definition.get("granularity"),
+                **(
+                    {"subType": definition.get("subType")}
+                    if definition.get("subType") is not None
+                    else {}
+                ),
             }
             for definition in meta_json["dataDefinitions"]
         ]
@@ -181,6 +186,7 @@ class Scenario:
         granularity: str,
         currency: Optional[str] = None,
         node: Optional[str] = None,
+        sub_type: Optional[str] = None,
         force_no_cache: bool = False,
         params: Optional[dict[str, str]] = None,
     ):
@@ -223,6 +229,10 @@ class Scenario:
             currency (Optional, String): The currency year to download the file
             in. Will default to `defaultCurrency` on the scenario if available.
             node (Optional, String): The node identifier to download nodal data for.
+            sub_type (Optional, String): The "subType" to disambiguate downloads
+            that share the same type and granularity (e.g. "generation" vs
+            "generation_pre_curtailment" for GBR technology downloads). You can
+            use "get_download_types" to see available subTypes.
 
         Returns:
             CSV as text string
@@ -252,7 +262,9 @@ class Scenario:
         download_meta_list = [
             d
             for d in meta_json.get("dataDefinitions")
-            if d.get("granularity") == granularity and d.get("type") == download_type
+            if d.get("granularity") == granularity
+            and d.get("type") == download_type
+            and (sub_type is None or d.get("subType") == sub_type)
         ]
 
         number_of_downloads = len(download_meta_list)
@@ -262,11 +274,16 @@ class Scenario:
                 if number_of_downloads == 0
                 else "Ambiguous download"
             )
+            sub_type_hint = (
+                " Try specifying the sub_type parameter to disambiguate."
+                if number_of_downloads > 1 and sub_type is None
+                else ""
+            )
             ex_msg = (
                 f"{issue_str} for {download_type}, {granularity} for {region}. "
                 f"Expected 1, found {number_of_downloads}. "
                 "Use Scenario.get_download_types to see what available "
-                "combinations there are for the scenario."
+                f"combinations there are for the scenario.{sub_type_hint}"
             )
             raise Exception(ex_msg)
 
@@ -357,6 +374,7 @@ class Scenario:
         download_type: str,
         granularity: str,
         currency: Optional[str] = None,
+        sub_type: Optional[str] = None,
         force_no_cache: bool = False,
         params: Optional[dict[str, str]] = None,
     ):
@@ -401,6 +419,7 @@ class Scenario:
             download_type=download_type,
             granularity=granularity,
             currency=currency,
+            sub_type=sub_type,
             force_no_cache=force_no_cache,
             params=params,
         )

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -125,6 +125,7 @@ def test_get_data_csvs():
             region,
             type_granularity_combo.get("type"),
             type_granularity_combo.get("granularity"),
+            sub_type=type_granularity_combo.get("subType"),
             force_no_cache=True,
         )
         for region in regions


### PR DESCRIPTION
## Summary

- **Bug:** GBR scenarios have multiple `dataDefinitions` entries sharing the same `type` and `granularity` but differing by `subType` (e.g. `"generation"` vs `"generation_pre_curtailment"` for technology at `30M` and `1h`). The filter in `get_scenario_data_csv` only matched on `type` and `granularity`, returning 2 results instead of 1 and raising an "Ambiguous download" error.
- **Fix:** Added an optional `sub_type` parameter to `get_scenario_data_csv` and `get_scenario_dataframe` that filters on `subType` when provided, allowing users to disambiguate.
- `get_download_types` now includes `subType` in its output when present, so users can discover available sub-types.
- Error message improved to suggest using `sub_type` when ambiguity is detected.
- Fully backward compatible — `sub_type` defaults to `None`, so existing code is unaffected.

## Test plan

- [ ] Verify `get_download_types('gbr')` now returns `subType` for technology entries at `30M` and `1h` granularities
- [ ] Verify `get_scenario_data_csv('gbr', 'technology', '30M', sub_type='generation')` succeeds without ambiguity error
- [ ] Verify `get_scenario_data_csv('gbr', 'technology', '30M', sub_type='generation_pre_curtailment')` downloads the correct pre-curtailment CSV
- [ ] Verify existing calls without `sub_type` (e.g. `get_scenario_data_csv('gbr', 'system', '1y')`) still work unchanged
- [ ] Verify calling without `sub_type` on an ambiguous type/granularity still raises a clear error with the new hint message

https://claude.ai/code/session_012RhSHwg69q2iBn2ANWVMYC