### PR TITLE
Add .aurora-architecture.yml for interactive architecture diagram

### DIFF
--- a/.aurora-architecture.yml
+++ b/.aurora-architecture.yml
@@ -1,0 +1,28 @@
+# .aurora-architecture.yml — aurora-origin-python-sdk
+
+services:
+  - id: origin_sdk
+    label: "Aurora Origin Python SDK"
+    shortLabel: "Origin SDK"
+    fullName: "aurora-origin-python-sdk"
+    cluster: external_clients
+    awsService: "Python Package"
+    runtime: "Python 3.10+"
+    runtimeLang: python
+    description: >
+      Python SDK for accessing data from Origin, Aurora's Market model platform.
+      Provides a programmatic interface via OriginSession for scenarios, outputs,
+      and publications.
+    details:
+      - "Installed via pip/uv from GitHub"
+      - "Authenticates with Aurora API key (~/.aurora-api-key or AURORA_API_KEY env var)"
+      - "Entry point: OriginSession class"
+      - "Supports Python 3.10 – 3.14"
+      - "Wraps REST and GraphQL endpoints exposed by API Gateway"
+    icon: python
+    iconType: svg
+    color: "bg-slate-200"
+    connections:
+      - to: api_gateway
+        label: "REST + GraphQL (SDK)"
+        interaction: api


### PR DESCRIPTION
## Summary

Adds a `.aurora-architecture.yml` file to this repo, declaring the services owned by this repository and their connections to other services in the Origin platform.

## What is this file?

This YAML file is consumed by the [Aurora Interactive Architecture](https://github.com/AuroraEnergyResearch/aurora-interactive-architecture) diagram generator. An LLM-based agent reads these files from all Origin repos and auto-generates an interactive architecture diagram showing all services, their connections, and data flows.

### Schema

Each file declares one or more `services` with:
- **Identity**: `id`, `label`, `shortLabel`, `fullName`
- **Infrastructure**: `cluster`, `awsService`, `runtime`, `runtimeLang`
- **Documentation**: `description`, `details`
- **Visual**: `icon`, `color`
- **Connections**: outbound edges to other services (`to`, `label`, `interaction`)

### Interaction types

`api` | `invoke` | `sns` | `sqs` | `workflow` | `storage` | `database` | `direct`

## Action required

Please review and merge. No code changes — this is a metadata file only.