### PR TITLE
Revert package name to aurora_origin_sdk

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,70 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
 # Aurora Origin SDK
 
-Python SDK for accessing data from Origin, Aurora's Market model platform.
+Python SDK for accessing data from Origin, Aurora's market model platform.
 
 # Installation
 
-> [!NOTE]
-> We support running the SDK in all currently supported versions of Python: 3.10 - 3.14.
-
-> [!WARNING]
-> Python 3.9 support is deprecated and will be removed in a future release. Please upgrade to Python 3.10 or later.
+We currently support running the SDK on all currently supported version of Python: 3.10 - 3.14.
 
 1. Install the package from the git repository
 
 ```bash
 # Use pip:
-pip install git+https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk
+pip install aurora-origin-sdk
 # Or uv:
-uv add git+https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk
+uv add aurora-origin-sdk
 ```
 
-2. Add your Aurora API key to the file $home/.aurora-api-key. for example `C:\Users\Joe Bloggs\.aurora-api-key` or set as the environment variable `AURORA_API_KEY`.
+2. Add your Aurora API key to the file `$home/.aurora-api-key`. for example `C:\Users\Joe Bloggs\.aurora-api-key` or set as the environment variable `AURORA_API_KEY`.
 
 3. Import `OriginSession` and initialise.
 

--- a/README_DEVELOP.md
+++ b/README_DEVELOP.md
@@ -1,7 +1,5 @@
 # Aurora Origin SDK
 
-## This is under development and not for general use.
-
 ## PR Checks
 
 GitHub Actions is set up to run the test suite against multiple versions of Python so that changes can be checked for compatibility.
@@ -45,3 +43,14 @@ Then check the result into `main`.
 
 The site will deploy automatically within a few minutes. The expected documentation can be found
 [here](https://auroraenergyresearch.github.io/aurora-origin-python-sdk/).
+
+
+## Releasing a new version to PyPi
+
+We have a github workflow set up in [./.github/workflows/python-publish.yml](./.github/workflows/python-publish.yml) which is triggered when a "Release" is created in github, and publishes the new version of the package to github.
+
+To cut a new release:
+
+1. Create the new release in Github (name it `v0.XX.YY`)
+2. When you click "publish", the build and publish workflow will kick off
+3. The workflow won't publish until you approve that step. Currently only Richard can do that.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aurora_origin_sdk"
+name = "auroraer_origin_sdk"
 version = "0.30.0"
 authors = [
   { name = "Aurora Development", email = "aurora_development@auroraer.com" },
@@ -24,7 +24,7 @@ dependencies = [
 requires-python = ">=3.9,<3.15"
 
 [dependency-groups]
-dev = ["aurora_origin_sdk[development]"]
+dev = ["auroraer_origin_sdk[development]"]
 
 [project.urls]
 repository = "https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "auroraer_origin_sdk"
+name = "aurora_origin_sdk"
 version = "0.30.0"
 authors = [
   { name = "Aurora Development", email = "aurora_development@auroraer.com" },


### PR DESCRIPTION
The rename to `auroraer_origin_sdk` (commits 88f2a53 / 9b7040d) broke the common requirements.txt pattern that consumers use:

```
aurora-origin-sdk@git+https://github.com/AuroraEnergyResearch/aurora-origin-python-sdk
```

This reverts the package name back to `aurora_origin_sdk` so existing consumers don't need to update their dependency lines.

Note: pip normalises `aurora_origin_sdk` and `aurora-origin-sdk` to the same thing, so both work. But `auroraer-origin-sdk` is a different name entirely.