### PR TITLE
[ORIGIN-3195] Expose pagination on project & scenario listing

### DIFF
--- a/src/origin_sdk/OriginSession.py
+++ b/src/origin_sdk/OriginSession.py
@@ -204,7 +204,10 @@ class OriginSession(APISession):
                 )
 
     def get_aurora_scenarios(
-        self, region: Optional[str] = None
+        self,
+        region: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[ScenarioSummaryType]:
         """
         Gets a list of all published Aurora scenarios.
@@ -216,6 +219,13 @@ class OriginSession(APISession):
             browsing the platform. You will see something like
             ".../launcher/aer/<REGION>"
 
+            limit (int, optional) - The maximum number of scenarios to return.
+            When omitted, all matching scenarios are returned.
+
+            offset (int, optional) - The number of scenarios to skip from the
+            start of the (most-recent-first) list. Only takes effect alongside
+            ``limit``.
+
         Returns:
             List[ScenarioSummaryType]
         """
@@ -223,7 +233,8 @@ class OriginSession(APISession):
         variables = {
             "filter": {
                 **({"regionGroupCode": region} if region is not None else {}),
-                # **(query_filter if query_filter is not None else {}),
+                **({"limit": limit} if limit is not None else {}),
+                **({"offset": offset} if offset is not None else {}),
                 "scenarioType": "AURORA_SCENARIO",
             }
         }
@@ -282,16 +293,78 @@ class OriginSession(APISession):
         variables = {"scenarioGlobalId": scenario_id}
         return self._graphql_request(url, scenario_query.launch_scenario, variables)
 
-    def get_projects(self) -> List[ProjectSummaryType]:
-        """ """
-        url = f"{self.scenario_service_graphql_url}"
-        return self._graphql_request(url, project_query.get_projects)
+    def get_projects(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        name: Optional[str] = None,
+    ) -> List[ProjectSummaryType]:
+        """
+        Gets the list of projects visible to the authenticated user.
 
-    def get_project(self, project_id: str) -> ProjectType:
-        """ """
+        Args:
+            limit (int, optional) - The maximum number of projects to return.
+            When omitted, all projects are returned.
+
+            offset (int, optional) - The number of projects to skip from the
+            start of the list. Only takes effect alongside ``limit``.
+
+            name (string, optional) - Case-insensitive substring filter on the
+            project name.
+
+        Returns:
+            List[ProjectSummaryType]
+        """
         url = f"{self.scenario_service_graphql_url}"
-        variables = {"projectId": project_id}
-        return self._graphql_request(url, project_query.get_project, variables)
+        variables = {
+            **({"limit": limit} if limit is not None else {}),
+            **({"offset": offset} if offset is not None else {}),
+            **({"name": name} if name is not None else {}),
+        }
+        query = project_query.build_get_projects(
+            limit=limit is not None,
+            offset=offset is not None,
+            name=name is not None,
+        )
+        return self._graphql_request(url, query, variables)
+
+    def get_project(
+        self,
+        project_id: str,
+        scenario_limit: Optional[int] = None,
+        scenario_offset: Optional[int] = None,
+    ) -> ProjectType:
+        """
+        Gets a single project, including its scenarios.
+
+        Args:
+            project_id (string) - The global id of the project.
+
+            scenario_limit (int, optional) - The maximum number of nested
+            scenarios to return. When omitted, all scenarios are returned.
+
+            scenario_offset (int, optional) - The number of nested scenarios to
+            skip from the start of the (most-recent-first) list. Only takes
+            effect alongside ``scenario_limit``.
+
+        Returns:
+            ProjectType
+        """
+        url = f"{self.scenario_service_graphql_url}"
+        variables = {
+            "projectId": project_id,
+            **({"scenarioLimit": scenario_limit} if scenario_limit is not None else {}),
+            **(
+                {"scenarioOffset": scenario_offset}
+                if scenario_offset is not None
+                else {}
+            ),
+        }
+        query = project_query.build_get_project(
+            scenario_limit=scenario_limit is not None,
+            scenario_offset=scenario_offset is not None,
+        )
+        return self._graphql_request(url, query, variables)
 
     def __get_dash_config(self):
         if self.dash_config_cache is None:

--- a/src/origin_sdk/gql/queries/project_queries.py
+++ b/src/origin_sdk/gql/queries/project_queries.py
@@ -14,19 +14,64 @@ query {
 }
 """
 
-get_projects = """
-query {
-  getProjects {
+
+def build_get_projects(limit=False, offset=False, name=False):
+    """Build the getProjects query.
+
+    Pagination variables are only declared/forwarded when the caller actually
+    supplies them. When none are supplied the query is identical to the
+    original, so it remains compatible with backends that predate pagination
+    support.
+    """
+    declarations = []
+    arguments = []
+    if limit:
+        declarations.append("$limit: Int")
+        arguments.append("limit: $limit")
+    if offset:
+        declarations.append("$offset: Int")
+        arguments.append("offset: $offset")
+    if name:
+        declarations.append("$name: String")
+        arguments.append("name: $name")
+
+    declaration_str = f" ({', '.join(declarations)})" if declarations else ""
+    argument_str = f" ({', '.join(arguments)})" if arguments else ""
+
+    return f"""
+query{declaration_str} {{
+  getProjects{argument_str} {{
     projectGlobalId
     name
     description
     isProjectPinned
-  }
-}
+  }}
+}}
 """
 
-get_project = f"""
-query ($projectId: String!) {{
+
+def build_get_project(scenario_limit=False, scenario_offset=False):
+    """Build the getProject query.
+
+    Nested-scenario pagination args are only declared/forwarded when supplied,
+    keeping the default query compatible with backends that predate pagination
+    support.
+    """
+    declarations = ["$projectId: String!"]
+    scenario_arguments = []
+    if scenario_limit:
+        declarations.append("$scenarioLimit: Int")
+        scenario_arguments.append("limit: $scenarioLimit")
+    if scenario_offset:
+        declarations.append("$scenarioOffset: Int")
+        scenario_arguments.append("offset: $scenarioOffset")
+
+    scenario_argument_str = (
+        f" ({', '.join(scenario_arguments)})" if scenario_arguments else ""
+    )
+
+    return f"""
+query ({', '.join(declarations)}) {{
   getProject (projectGlobalId: $projectId) {{
     projectGlobalId
     name
@@ -34,12 +79,13 @@ query ($projectId: String!) {{
     productName
     productId
     isProjectPinned
-    scenarios {{
+    scenarios{scenario_argument_str} {{
       {scenario_summary_fields}
     }}
   }}
 }}
 """
+
 
 create_project = """
 mutation ($project: InputProject!) {

--- a/tests/test_pagination_variables.py
+++ b/tests/test_pagination_variables.py
@@ -1,0 +1,116 @@
+"""Unit tests for the pagination arguments on the listing endpoints.
+
+These do not hit the network: ``_graphql_request`` is patched to capture the
+GraphQL variables that the session would send.
+"""
+
+from unittest.mock import patch
+
+from origin_sdk.OriginSession import OriginSession
+
+
+def _query_and_variables_for(call):
+    # _graphql_request is called as (url, query, variables) because
+    # patch.object replaces the attribute (self is not re-bound).
+    args, kwargs = call
+    query = kwargs.get("query", args[1] if len(args) > 1 else None)
+    variables = kwargs.get("variables", args[2] if len(args) > 2 else None)
+    return query, variables
+
+
+def _capture(method_name, *args, **kwargs):
+    session = OriginSession({"token": "test-token"})
+    with patch.object(
+        OriginSession, "_graphql_request", return_value=[]
+    ) as mock_request:
+        getattr(session, method_name)(*args, **kwargs)
+    return _query_and_variables_for(mock_request.call_args)
+
+
+def _call_capturing(method_name, *args, **kwargs):
+    _query, variables = _capture(method_name, *args, **kwargs)
+    return variables
+
+
+def test_get_projects_omits_pagination_when_not_supplied():
+    assert _call_capturing("get_projects") == {}
+
+
+def test_get_projects_includes_supplied_pagination():
+    assert _call_capturing("get_projects", limit=10, offset=20, name="GB") == {
+        "limit": 10,
+        "offset": 20,
+        "name": "GB",
+    }
+
+
+def test_get_projects_includes_only_supplied_fields():
+    assert _call_capturing("get_projects", name="GB") == {"name": "GB"}
+
+
+def test_get_project_forwards_scenario_pagination():
+    assert _call_capturing(
+        "get_project", "project-id", scenario_limit=5, scenario_offset=2
+    ) == {
+        "projectId": "project-id",
+        "scenarioLimit": 5,
+        "scenarioOffset": 2,
+    }
+
+
+def test_get_project_without_pagination_only_sends_id():
+    assert _call_capturing("get_project", "project-id") == {"projectId": "project-id"}
+
+
+def test_get_aurora_scenarios_includes_pagination_in_filter():
+    assert _call_capturing(
+        "get_aurora_scenarios", region="GBR", limit=5, offset=10
+    ) == {
+        "filter": {
+            "regionGroupCode": "GBR",
+            "limit": 5,
+            "offset": 10,
+            "scenarioType": "AURORA_SCENARIO",
+        }
+    }
+
+
+def test_get_aurora_scenarios_without_pagination_unchanged():
+    assert _call_capturing("get_aurora_scenarios", region="GBR") == {
+        "filter": {
+            "regionGroupCode": "GBR",
+            "scenarioType": "AURORA_SCENARIO",
+        }
+    }
+
+
+# --- Backward compatibility: a no-pagination call must not reference the new
+# pagination arguments in the query text, so it stays valid against backends
+# that predate pagination support. ---
+
+
+def test_get_projects_query_omits_pagination_args_by_default():
+    query, _ = _capture("get_projects")
+    assert "limit" not in query
+    assert "offset" not in query
+    assert "name: $name" not in query
+
+
+def test_get_projects_query_includes_requested_pagination_args():
+    query, _ = _capture("get_projects", limit=5)
+    assert "$limit: Int" in query
+    assert "limit: $limit" in query
+    assert "offset" not in query
+
+
+def test_get_project_query_omits_scenario_pagination_by_default():
+    query, _ = _capture("get_project", "project-id")
+    assert "scenarioLimit" not in query
+    assert "scenarioOffset" not in query
+    assert "scenarios {" in query
+
+
+def test_get_project_query_includes_requested_scenario_pagination():
+    query, _ = _capture("get_project", "project-id", scenario_limit=10)
+    assert "$scenarioLimit: Int" in query
+    assert "limit: $scenarioLimit" in query


### PR DESCRIPTION
[ORIGIN-3195]

## Why
Large project/scenario lists overflow downstream consumers (notably the MCP tool-result size limit). This adds pagination so callers can fetch in pages.

## What
- `get_projects(limit=None, offset=None, name=None)`
- `get_project(project_id, scenario_limit=None, scenario_offset=None)` — paginates the nested scenarios
- `get_aurora_scenarios(region=None, limit=None, offset=None)`

### Backward compatibility
The project GraphQL queries are **built dynamically** — pagination variables/args are only included when the caller actually supplies them. A call with no pagination args sends the byte-for-byte original query, so the SDK still works against backends that predate pagination support (verified in tests).

## Tests
New `tests/test_pagination_variables.py` asserts the GraphQL variables and that the default query omits the new args. Verified network-free via `unittest.mock.patch.object`.

> Note: the SDK's pytest suite uses a `scope="session"` autouse fixture that provisions data against a live backend, so the full suite only runs in CI against a deployed environment. The new tests are network-free and were validated standalone.

## Rollout
Depends on the backend PR (`scenario-explorer-microservice` ORIGIN-3195-paginate-projects-scenarios) being deployed to the target environment first, otherwise paginated calls will be rejected by the GraphQL schema. Default (non-paginated) calls remain compatible regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ORIGIN-3195]: https://auroraenergy.atlassian.net/browse/ORIGIN-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ